### PR TITLE
Fix android studio location for Linux in android task

### DIFF
--- a/scripts/android.js
+++ b/scripts/android.js
@@ -202,6 +202,10 @@ checkBuild(function () {
               cmd(path.resolve('C:/Programme/Android/Android Studio/bin'), ['start', 'studio64.exe', '"' + path.resolve(cfg.packageRoot, 'cordova/platforms/android') + '"'], function () {
                 showOnly('Android Studio started with build version ' + version)
               })
+            } else if (process.platform === 'linux') {
+              run('/usr/bin/android-studio "' + path.resolve(cfg.packageRoot, 'cordova/platforms/android') + '"', function () {
+                showOnly('Android Studio started with build version ' + version)
+	      }) 
             } else {
               run('open -a "/Applications/Android Studio.app" "' + path.resolve(cfg.packageRoot, 'cordova/platforms/android') + '"', function () {
                 showOnly('Android Studio started with build version ' + version)


### PR DESCRIPTION
Allows the android task to run successfully on Linux distributions. May need to find a way to make the path more dynamic in the future but `/usr/bin` should capture most distributions.