### PR TITLE
JS error when DOM element not found

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -994,7 +994,8 @@ mixins.manageState = {
       function getViewSel (el) {
         el = window.Dom7(el.target || el).parents('.view')
         return (el.attr('id') !== '' && el.attr('id') !== null ? '#' + el.attr('id') : '') +
-               (el[0].classList.length > 0 ? '.' + el[0].classList.value.replace(/ /g, '.') : '')
+               (el.length && el[0].classList.length > 0 ? '.' +
+               el[0].classList.value.replace(/ /g, '.') : '');
       }
       function getViewUrl (el) {
         let viewSel = getViewSel(el)


### PR DESCRIPTION
`Cannot read property 'classList' of undefined` when switching Tabs in a Navigation Bar after a fresh page refresh (doesn't happen after hot module reload)