### PR TITLE
App folder exluded from Babel loader

### DIFF
--- a/lib/webpack-config.js
+++ b/lib/webpack-config.js
@@ -30,7 +30,7 @@ let createConfiguration = function (mode) {
       include: [
         abs(__dirname, '../lib'),
         abs(__dirname, '../scripts'),
-        abs(env.app, 'app')
+        abs(env.app)
       ]
     },
     // Vue files


### PR DESCRIPTION
This allows babel transpiling to work on other js files in the `app/` directory, such as `lib` files that might act as helpers with `import`/`export` support.