### PR TITLE
Add custom Cordova preferences

### DIFF
--- a/config-scheme.json
+++ b/config-scheme.json
@@ -154,6 +154,10 @@
     "type": "array",
     "default": []
   },
+  "cordovaPreferences": {
+    "type": "object",
+    "default": {}
+  },
   "resetLocalStorageOnVersionChange": {
     "type": "boolean",
     "default": false

--- a/scripts/cordova.js
+++ b/scripts/cordova.js
@@ -183,6 +183,19 @@ let updateCordovaConfig = function (callback) {
       'value': true
     }
   }
+  // Apply custom Cordova preferences
+  if (env.cfg.cordovaPreferences !== undefined) {
+    var preferences = [config.preference];
+    for (var key in env.cfg.cordovaPreferences) {
+      preferences.push({
+        '$': {
+          'name': key,
+          'value': env.cfg.cordovaPreferences[key]
+        }
+      })
+    }
+    config.preference = preferences;
+  }
   // Add Android platform
   if (env.arg.android === true || env.arg.studio) {
     config.platform = {


### PR DESCRIPTION
This pull requests adds an option to create custom Cordova preferences in generated config.xml file. It is required for configuring Cordova. Here's an example from my `config.json` which allows to focus input fields programmatically on iOS:

```
  "cordovaPreferences": {
    "KeyboardDisplayRequiresUserAction": false
  },
```